### PR TITLE
change interpreter to oracle

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ val tests_from_dir :
   ?compile_flags:string ->
   runtime:string ->
   compiler:compiler ->
-  ?interpreter:(string -> string) ->
+  ?oracle:(string -> status * string) ->
   string -> (string * unit Alcotest.test_case list) list
 ```
 
@@ -98,4 +98,4 @@ It uses the extension `.bbc` and is composed of a few sections that appear in th
 - `PARAMS:` [optional, default empty] : a `,`-separated list of pairs `VAR=VAL` that are added to the environment variables of the compiled executable
 - `STATUS:` [optional, default `No error`] : either `CT error` (compile time error), `RT error` (runtime error) or `No error`/ Needs to be set to the appropriate error if the program is expected to fail either at compile time or at runtime. In that case the content of `EXPECTED:` is interpreted as a pattern (see [Str](https://caml.inria.fr/pub/docs/manual-ocaml/libref/Str.html)) matched against the output of the failing phase.
 - `SRC:` : the source of the program fed to the compiler
-- `EXPECTED:` : the expected result of the program (note that debugging messages starting by `|` are ignored and shouldn't be part of the expected result). If the expected result ends with the message `|INTERPRET` then the expected result is obtained by substituting `|INTERPRET` with the result of evaluating the interpreter on the source code.
+- `EXPECTED:` : the expected result of the program (note that debugging messages starting by `|` are ignored and shouldn't be part of the expected result). If the expected result ends with the message `|ORACLE` then the expected result is obtained by substituting `|ORACLE` with the result of a provided oracle called on the source code.

--- a/test.mli
+++ b/test.mli
@@ -64,11 +64,12 @@ val testfiles_in_dir : string -> string list
     to process the sources.
     [compile_flags] are passed to the C compiler (clang),
     defaulting to "-g".
-    The optional [interpreter] parameter is the interpreter function to be invoked on source files 
-    (whenever the expected result of a test file mentions `|INTERPRET`). *)
+    The optional [oracle] parameter is an interpreter oracle to be invoked on source files.
+    It should return a result status together with the expected output of the corresponding program,
+    that will be substituted in the first mention of `|ORACLE` in a test file, if any. *)
 val tests_from_dir :
   ?compile_flags:string ->
   runtime:string ->
   compiler:compiler ->
-  ?interpreter:(string -> string) ->
+  ?oracle:(string -> status * string) ->
   string -> (string * unit Alcotest.test_case list) list

--- a/test.mli
+++ b/test.mli
@@ -64,7 +64,7 @@ val testfiles_in_dir : string -> string list
     to process the sources.
     [compile_flags] are passed to the C compiler (clang),
     defaulting to "-g".
-    The optional [oracle] parameter is an interpreter oracle to be invoked on source files.
+    The optional [oracle] parameter is an oracle (eg. an interpreter, reference compiler) to be invoked on source files.
     It should return a result status together with the expected output of the corresponding program,
     that will be substituted in the first mention of `|ORACLE` in a test file, if any. *)
 val tests_from_dir :


### PR DESCRIPTION
Example of migration: https://github.com/pleiad/CDI-reference/tree/entrega1-oracle